### PR TITLE
Include "templates" dir when creating packages with distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
             'vectordraw = vectordraw:VectorDrawXBlock',
         ]
     },
-    package_data=package_data("vectordraw", ["static", "public"]),
+    package_data=package_data("vectordraw", ["static", "public", "templates"]),
 )


### PR DESCRIPTION
![](http://i.imgur.com/xS187Us.png)

After installing the XBlock (https://github.com/edx/edx-platform/wiki/Installing-a-new-XBlock), rendering will fail because the package needs to contain all templates necessary for rendering. This change includes the template dir.