### PR TITLE
Used problem icon in vector draw xblock

### DIFF
--- a/vectordraw/vectordraw.py
+++ b/vectordraw/vectordraw.py
@@ -31,6 +31,8 @@ class VectorDrawXBlock(StudioEditableXBlockMixin, XBlock):
     An XBlock that allows course authors to define vector drawing exercises.
     """
 
+    icon_class = "problem"
+
     # Content
     display_name = String(
         display_name="Title (display name)",


### PR DESCRIPTION
This fixes [xblock-vectordraw/issues/7](https://github.com/open-craft/xblock-vectordraw/issues/7).

Testing instructions:

1. Set up a devstack.

2. Install the xblock on this branch into the edxapp Python virtualenv.
 ```
# In the same directory as your Vagrantfile:
vagrant ssh -- sudo -u edxapp /edx/bin/pip.edxapp install -e git+https://github.com/replaceafill/xblock-vectordraw.git@issue_7#egg=xblock-vectordraw
```

3. Run Studio and LMS

4. Navigate to a course, and then "Settings > Advanced Settings".

5. Update the "Advanced Module List" field to contain ["vectordraw"].

6. Click "Save Changes".

7. Navigate to the outline and create a new Section, Subsection, and Unit. You will be redirected to the Unit authoring view.

8. Select "Advanced > Vector Drawing" to create a new Vector Drawing problem.

9. Click "Preview" and observe the problem icon in the LMS sequence navigation bar.